### PR TITLE
Fix Convert query recent iocs 

### DIFF
--- a/threatfox_query_recent-iocs.py
+++ b/threatfox_query_recent-iocs.py
@@ -12,7 +12,7 @@ pool = urllib3.HTTPSConnectionPool('threatfox-api.abuse.ch', port=443, maxsize=5
 
 data = {
     'query':    'get_iocs',
-    'days':     sys.argv[1]
+    'days':     int(sys.argv[1])
 }
 json_data = json.dumps(data)
 response = pool.request("POST", "/api/v1/", body=json_data)


### PR DESCRIPTION
Current exemple doesn't work as the API need an integer for `days` :

```console
$ python3 threatfox.py 1
{
    "query_status": "illegal_days",
    "data": "Invalid value for parameter days (must be digit between 1 or 7)"
}
```

